### PR TITLE
Adding retries on error

### DIFF
--- a/send.py
+++ b/send.py
@@ -2,6 +2,8 @@ import os
 import requests
 import re
 import sys
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 
 status_map = {
     '0': "SUCCESSFUL",
@@ -89,8 +91,18 @@ else:
 print('Payload: {}'.format(payload))
 
 print('Sending payload to {}'.format(url))
+retry_strategy = Retry(
+    total=3,
+    status_forcelist=[429, 502, 503, 504],
+    allowed_methods=["POST", "PUT"],
+    raise_on_status=True,
+    backoff_factor= 10
+)
+adapter = HTTPAdapter(max_retries=retry_strategy)
+http = requests.Session()
+http.mount("https://", adapter)
 request_headers = {'Authorization': auth_token}
-r = requests.post(url, json=payload, headers=request_headers)
+r = http.post(url, json=payload, headers=request_headers)
 
 if r.status_code != 200:
     print('Unable to send build info to {}'.format(url))

--- a/send.py
+++ b/send.py
@@ -94,7 +94,7 @@ print('Sending payload to {}'.format(url))
 retry_strategy = Retry(
     total=3,
     status_forcelist=[429, 502, 503, 504],
-    allowed_methods=["POST", "PUT"],
+    method_whitelist=["POST", "PUT"],
     raise_on_status=True,
     backoff_factor= 10
 )


### PR DESCRIPTION
Retries 3 times with a 10 second backoff if it receives a retryable error. Will prevent issues where posting to ez-deploy fails due to pods rolling