### PR TITLE
Making step non skippable

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -25,7 +25,7 @@ type_tags:
 
 is_requires_admin_user: false
 is_always_run: true
-is_skippable: true
+is_skippable: false
 
 toolkit:
   bash:


### PR DESCRIPTION
Making this step non skippable to avoid issues like this: https://app.bitrise.io/build/7827a007-c707-41bd-8501-c4dd524cc52d#?tab=log (missing commit hash)